### PR TITLE
Use pip3 instead of pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV pip_packages "pipenv ansible pyopenssl"
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
        apt-utils \
-       python-setuptools \
+       python3-setuptools \
        python3-pip \
        python-pip \
        ca-certificates \
@@ -18,8 +18,8 @@ RUN apt-get update \
     && apt-get clean
 
 # Install Ansible via Pip.
-RUN pip install -U pip
-RUN pip install $pip_packages
+RUN pip3 install -U pip
+RUN pip3 install $pip_packages
 
 # Install Ansible inventory file.
 RUN mkdir -p /etc/ansible


### PR DESCRIPTION
All the issues I was having building this on a Mac M1 magically disappear when using python3 and a newer version of pip.  I am able to run various molecule tests successfully against the resulting image.

To build and push, you should be able to run `docker buildx build --platform linux/arm64/v8,linux/amd64 -t puldocker-ubuntu1804-ansible:latest --push .`

I also pushed a multi-arch version of this image to ghcr.io/sandbergja/puldocker-ubuntu1804-ansible:latest in case you want to try it out.